### PR TITLE
add vars for vpc cidr blocks

### DIFF
--- a/terraform/aws/demo-multi-region/main.tf
+++ b/terraform/aws/demo-multi-region/main.tf
@@ -7,7 +7,7 @@ module "cluster_main" {
   aws_region    = "${var.aws_region}"
   consul_dc     = "${var.consul_dc}"
   consul_acl_dc = "${var.consul_dc}"
-  vpc_netblock  = "10.0.0.0/16"
+  vpc_netblock  = "${var.vpc_cidr_main}"
 
   project_name     = "${var.project_name}"
   top_level_domain = "${var.top_level_domain}"
@@ -26,7 +26,7 @@ module "cluster_alt" {
   aws_region    = "${var.aws_region_alt}"
   consul_dc     = "${var.consul_dc_alt}"
   consul_acl_dc = "${var.consul_dc}"
-  vpc_netblock  = "10.128.0.0/16"
+  vpc_netblock  = "${var.vpc_cidr_alt}"
 
   project_name     = "${var.project_name}"
   top_level_domain = "${var.top_level_domain}"
@@ -94,6 +94,8 @@ module "link_vpc" {
   vpc_id_alt          = "${module.cluster_alt.vpc_id}"
   route_table_id_main = "${module.cluster_main.vpc_public_route_table_id}"
   route_table_id_alt  = "${module.cluster_alt.vpc_public_route_table_id}"
+  cidr_block_alt      = "${var.vpc_cidr_alt}"
+  cidr_block_main     = "${var.vpc_cidr_main}"
 
   hashi_tags = "${var.hashi_tags}"
 }

--- a/terraform/aws/demo-multi-region/variables.tf
+++ b/terraform/aws/demo-multi-region/variables.tf
@@ -14,6 +14,16 @@ variable "hashi_tags" {
   }
 }
 
+variable "vpc_cidr_main" {
+  description = "The netblock for the main VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_cidr_alt" {
+  description = "The netblock for the alt VPC"
+  default     = "10.128.0.0/16"
+}
+
 variable "ssh_key_name" {
   description = "Name of existing AWS ssh key"
 }

--- a/terraform/aws/modules/link-vpc/main.tf
+++ b/terraform/aws/modules/link-vpc/main.tf
@@ -39,13 +39,13 @@ resource "aws_vpc_peering_connection_accepter" "alt" {
 resource "aws_route" "main_to_alt" {
   provider                  = "aws.main"
   route_table_id            = "${var.route_table_id_main}"
-  destination_cidr_block    = "10.128.0.0/16"
+  destination_cidr_block    = "${var.cidr_block_alt}"
   vpc_peering_connection_id = "${aws_vpc_peering_connection.main.id}"
 }
 
 resource "aws_route" "alt_to_main" {
   provider                  = "aws.alt"
   route_table_id            = "${var.route_table_id_alt}"
-  destination_cidr_block    = "10.0.0.0/16"
+  destination_cidr_block    = "${var.cidr_block_main}"
   vpc_peering_connection_id = "${aws_vpc_peering_connection_accepter.alt.id}"
 }

--- a/terraform/aws/modules/link-vpc/variables.tf
+++ b/terraform/aws/modules/link-vpc/variables.tf
@@ -33,3 +33,11 @@ variable "route_table_id_main" {
 variable "route_table_id_alt" {
   description = "Alt VPC Route Table ID"
 }
+
+variable "cidr_block_main" {
+  description = "The netblock for the main VPC"
+}
+
+variable "cidr_block_alt" {
+  description = "The netblock for the alt VPC"
+}


### PR DESCRIPTION
Add vars to multi-region demo to ensure CIDR blocks used for each cluster are also used when connecting the VPCs
- Before this commit, the `link-vpc` module included hard-coded CIDR blocks
- The hardcoded values matched those used in creating the clusters in `master.tf`, but this prevents deviation in the future.