### PR TITLE
Multi-region demo fixes, improvements and demo bootstrapping

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -96,6 +96,13 @@ This will take a couple minutes to run. Once the command prompt returns, wait a 
   - get fqdn of Consul LB `terraform output consul-lb`
   - Open value returned in format `http://<consul_server_fqdn>:8500/ui`
 
+### Multi Region - Temporary Setup Step - connect consul clusters
+
+- In the Consul UI, on the Kay/Value tab, copy the value of the key `server_ips`
+- Connect to a Consul Server in each DC
+  - type the following command: `consul join -wan <paste value of server_ips here>`
+  - remember run this on one consul server in each DC
+
 ### Consul Service Discovery
 
 - We're going to review a service using Consul for Service Discovery
@@ -219,23 +226,17 @@ This will take a couple minutes to run. Once the command prompt returns, wait a 
      - If you double the number of backends, you have to add _another_ 240 endpoint combinations
      - With Intentions, you do _nothing_ because intentions follow the service
 
-### Configuration K/V - displayed on webclient UI (under Configuration)
+### Configuration K/V - displayed on webclient UI
 
-- Populate K/V items on the webclient UI by adding KV entries in Consul
-- On Consul Web UI, create entry `product/` and save
-  - Any K/V's created under `product/` will display in the webclient UI
-  - In Consul Web UI select `product/` folder & create a key called `test` and assign it a value
 - On webclient UI, point out **Configuration** Section
-  - the `product` service reads the Consul K/V store (along with the mongodb records) & returns them to `web_client` where they are displayed
+  - the `product` service reads the Consul K/V store (along with the mongodb records)
+  - data returns to `web_client` and displayed
 
 ### Multi-Region Demo (Only) - Failover with Prepared Queries
 
 > Webclient service is configured to use a "prepared query" to find the `product` service.
 > If every product service in the current DC fails, it looks for the service in other DCs
 
-- Setup
-  - Create a `product/` K/V folder on each DC
-  - in `product/` create a key called "test" with different values in each DC
 - Open `web_client` for DC1
   - point out **Configuration** Section
     - lists **datacenter = dc1** and the value of **test** set for DC1

--- a/terraform/aws/demo-multi-region/main.tf
+++ b/terraform/aws/demo-multi-region/main.tf
@@ -88,14 +88,15 @@ resource "consul_prepared_query" "product_service_alt" {
 module "link_vpc" {
   source = "../modules/link-vpc"
 
-  aws_region_main     = "${var.aws_region}"
-  aws_region_alt      = "${var.aws_region_alt}"
+  aws_region_main     = "${module.cluster_main.aws_region}"
   vpc_id_main         = "${module.cluster_main.vpc_id}"
-  vpc_id_alt          = "${module.cluster_alt.vpc_id}"
   route_table_id_main = "${module.cluster_main.vpc_public_route_table_id}"
-  route_table_id_alt  = "${module.cluster_alt.vpc_public_route_table_id}"
-  cidr_block_alt      = "${var.vpc_cidr_alt}"
-  cidr_block_main     = "${var.vpc_cidr_main}"
+  cidr_block_main     = "${module.cluster_main.vpc_netblock}"
+
+  aws_region_alt     = "${module.cluster_alt.aws_region}"
+  vpc_id_alt         = "${module.cluster_alt.vpc_id}"
+  route_table_id_alt = "${module.cluster_alt.vpc_public_route_table_id}"
+  cidr_block_alt     = "${module.cluster_alt.vpc_netblock}"
 
   hashi_tags = "${var.hashi_tags}"
 }

--- a/terraform/aws/demo-one-region/main.tf
+++ b/terraform/aws/demo-one-region/main.tf
@@ -36,3 +36,23 @@ resource "consul_prepared_query" "product_service" {
     datacenters = ["${module.cluster_main.consul_dc}"]
   }
 }
+
+resource "consul_keys" "server_ips_main" {
+  provider = "consul.main"
+
+  key {
+    path   = "product/enable_hyper_speed"
+    value  = "true"
+    delete = true
+  }
+}
+
+resource "consul_keys" "server_ips_alt" {
+  provider = "consul.alt"
+
+  key {
+    path   = "product/enable_hyper_speed"
+    value  = "true"
+    delete = true
+  }
+}

--- a/terraform/aws/modules/consul-demo-cluster/outputs.tf
+++ b/terraform/aws/modules/consul-demo-cluster/outputs.tf
@@ -16,6 +16,10 @@ output "vpc_id" {
   value = "${aws_vpc.prod.id}"
 }
 
+output "vpc_netblock" {
+  value = "${var.vpc_netblock}"
+}
+
 output "public_subnets" {
   value = "${aws_subnet.public.*.cidr_block}"
 }
@@ -30,6 +34,10 @@ output "consul_lb" {
 
 output "consul_servers" {
   value = ["${aws_route53_record.consul_a_records.*.fqdn}"]
+}
+
+output "consul_servers_private_ip" {
+  value = ["${aws_instance.consul.*.private_ip}"]
 }
 
 output "webclient_lb" {

--- a/terraform/aws/modules/consul-demo-cluster/vpc.tf
+++ b/terraform/aws/modules/consul-demo-cluster/vpc.tf
@@ -21,6 +21,10 @@ resource "aws_route_table" "public" {
   }
 
   tags = "${merge(map("Name", "public route table"), var.hashi_tags)}"
+
+  lifecycle {
+    ignore_changes = "route"
+  }
 }
 
 resource "aws_subnet" "public" {


### PR DESCRIPTION
- readme updated 
  - connecting Consul clusters in separate DCs (temporary until bootstrapped)
  - demo instructions for multi-region failover
- 'consul-demo-cluster` module updates
  - added fix to prevent a rerun of terraform apply from removing inter-VPC route from routing table
  - added output for consul server private IPs (used in multi-region demo)
  - added output for netblock (used by `link_vpc` module as input)
- single region demo
  - writes `product/enable_hyper_speed` key to Consul KV store
- multi-region demo
  - writes space separated list of Consul private IPs to `server_ips` in Consul KV store
    - used for to retrieve list of all consul servers in order to perform `consul join -wan <values>`
    - for future use by service or bootstrap to perform join automatically
  - writes `product/enable_hyper_speed` key to Consul KV store