### PR TITLE
Add Terraform provisioner to join clusters via ssh

### DIFF
--- a/terraform/aws/demo-multi-region/main.tf
+++ b/terraform/aws/demo-multi-region/main.tf
@@ -98,7 +98,7 @@ resource "consul_prepared_query" "product_service_alt" {
   service = "product"
 
   failover {
-    datacenters = ["${module.cluster_main.consul_dc}", "${module.cluster_alt.consul_dc}"]
+    datacenters = ["${module.cluster_alt.consul_dc}", "${module.cluster_main.consul_dc}"]
   }
 }
 
@@ -116,6 +116,12 @@ resource "consul_keys" "server_ips_main" {
     value  = "true"
     delete = true
   }
+
+  key {
+    path   = "product/run"
+    value  = "true"
+    delete = true
+  }
 }
 
 # Add configuration data to Consul KV in alt DC
@@ -129,6 +135,12 @@ resource "consul_keys" "server_ips_alt" {
 
   key {
     path   = "product/enable_hyper_speed"
+    value  = "true"
+    delete = true
+  }
+
+  key {
+    path   = "product/run"
     value  = "true"
     delete = true
   }

--- a/terraform/aws/demo-multi-region/terraform.auto.tfvars.example
+++ b/terraform/aws/demo-multi-region/terraform.auto.tfvars.example
@@ -27,6 +27,10 @@ hashi_tags = {
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html
 ssh_key_name = "thomas-yubikey"
 
+# Private SSH key that is referenced by ssh_key_name variable
+#   if not defined, the counsul datacenters will not be joined in post provisioning
+ssh_pri_key_file = "~/.ssh/id_rsa"
+
 # zone ID for TLD
 route53_zone_id = "ZZZZZZZZZZZZZZ"
 

--- a/terraform/aws/demo-multi-region/variables.tf
+++ b/terraform/aws/demo-multi-region/variables.tf
@@ -36,6 +36,11 @@ variable "consul_dc_alt" {
   description = "Alternate Consul cluster DC name"
 }
 
+variable "ssh_pri_key_file" {
+  description = "Private SSH key for post provisioning config"
+  default     = ""
+}
+
 # Do we need this in multi-region TF file?  Isnt it always the DC of main?
 # variable "consul_acl_dc" {
 #   description = "Consul ACL cluster name"


### PR DESCRIPTION
- if new var `ssh_pri_key_file` set to point to the aws ssh key, a `remote_exec` provisioner will connect to a consul server in each DC and run the connect command
- if `ssh_pri_key_file` is not defined by user, it defaults to "" and the `remote_exec` provisioner does not run, in which case the user will need to manually join the DC's to each other
  - the consul server private IP's are stored in Consul KV key `server_ips` (in both DCs)
  - the cluster can be joined with this command: `consul join -wan $(consul kv get server_ips)`

## Notes
- DC2 does not reach an operational state until ~ 15 minutes after `terraform apply` completes
  - debug logs do not indicate a cause for this, although DC2 using DC1 as it's ACL_DC is the suspected cause
- Make sure the environment is created at least 15 minutes before you need to show DC2