### PR TITLE
Adjust Packer templates and bootstrap scripts

### DIFF
--- a/packer/Makefile
+++ b/packer/Makefile
@@ -43,19 +43,19 @@ aws_client_webclient: aws_consul_client .built.aws_client_webclient
 	touch .built.aws_consul_server
 
 .built.aws_client_listing: client_listing.json files/install_node.sh services/listing.hcl files/listing.service
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs client_listing.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs client_listing.json
 	touch .built.aws_client_listing
 
 .built.aws_client_mongodb: client_mongodb.json services/mongodb.hcl files/mongod.conf
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs client_mongodb.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs client_mongodb.json
 	touch .built.aws_client_mongodb
 
 .built.aws_client_product: client_product.json services/product.hcl files/product.service
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs client_product.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs client_product.json
 	touch .built.aws_client_product
 
 .built.aws_client_webclient: client_webclient.json services/web_client.hcl files/web_client.service
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs client_webclient.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs client_webclient.json
 	touch .built.aws_client_webclient
 
 $(ENCRYPT_CONFIG):

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -1,6 +1,7 @@
 ENCRYPT_CONFIG := files/encrypt.hcl
 
 AMI_OWNER=753646501470
+CONSUL_VER="1.5.2"
 
 DEFAULT:
 	@echo Run 'make aws' to build appropriate images
@@ -30,15 +31,15 @@ aws_client_product: aws_consul_client .built.aws_client_product
 aws_client_webclient: aws_consul_client .built.aws_client_webclient
 
 .built.aws_consul_base: consul_base.json files/install_base.sh files/install_consul.sh
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs consul_base.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs consul_base.json
 	touch .built.aws_consul_base
 
 .built.aws_consul_client: consul_client.json files/auto-join-aws.hcl.tmpl files/update-consul-join-config files/client.hcl
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs consul_client.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs consul_client.json
 	touch .built.aws_consul_client
 
 .built.aws_consul_server: consul_server.json files/server.hcl
-	AMI_OWNER=$(AMI_OWNER) packer build -only amazon-ebs consul_server.json
+	AMI_OWNER=$(AMI_OWNER) CONSUL_VER=$(CONSUL_VER) packer build -only amazon-ebs consul_server.json
 	touch .built.aws_consul_server
 
 .built.aws_client_listing: client_listing.json files/install_node.sh services/listing.hcl files/listing.service

--- a/packer/client_listing.json
+++ b/packer/client_listing.json
@@ -9,7 +9,7 @@
         "role": "consul-client-listing",
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
+        "proj_suffix_tag": "Q3-2019",
         "type": "{{ env `NODE_TYPE` }}"
     },
     "builders": [{
@@ -47,7 +47,8 @@
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [{

--- a/packer/client_listing.json
+++ b/packer/client_listing.json
@@ -10,7 +10,8 @@
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
         "proj_suffix_tag": "Q3-2019",
-        "type": "{{ env `NODE_TYPE` }}"
+        "type": "{{ env `NODE_TYPE` }}",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-{{ user `type` }}-listing",
@@ -46,6 +47,7 @@
                 "project": "CC Demo {{ user `proj_suffix_tag` }}",
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
+                "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
             },
             "ami_groups": ["all"]

--- a/packer/client_mongodb.json
+++ b/packer/client_mongodb.json
@@ -10,7 +10,8 @@
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
         "proj_suffix_tag": "Q3-2019",
-        "type": "{{ env `NODE_TYPE` }}"
+        "type": "{{ env `NODE_TYPE` }}",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-{{ user `type` }}-mongodb",
@@ -46,6 +47,7 @@
                 "project": "CC Demo {{ user `proj_suffix_tag` }}",
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
+                "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
             },
             "ami_groups": ["all"]

--- a/packer/client_mongodb.json
+++ b/packer/client_mongodb.json
@@ -9,7 +9,7 @@
         "role": "consul-client-listing",
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
+        "proj_suffix_tag": "Q3-2019",
         "type": "{{ env `NODE_TYPE` }}"
     },
     "builders": [{
@@ -47,7 +47,8 @@
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [

--- a/packer/client_product.json
+++ b/packer/client_product.json
@@ -9,7 +9,7 @@
         "role": "consul-client-product",
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
+        "proj_suffix_tag": "Q3-2019",
         "type": "{{ env `NODE_TYPE` }}"
     },
     "builders": [{
@@ -47,7 +47,8 @@
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [{

--- a/packer/client_product.json
+++ b/packer/client_product.json
@@ -10,7 +10,8 @@
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
         "proj_suffix_tag": "Q3-2019",
-        "type": "{{ env `NODE_TYPE` }}"
+        "type": "{{ env `NODE_TYPE` }}",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-{{ user `type` }}-product",
@@ -46,6 +47,7 @@
                 "project": "CC Demo {{ user `proj_suffix_tag` }}",
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
+                "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
             },
             "ami_groups": ["all"]

--- a/packer/client_webclient.json
+++ b/packer/client_webclient.json
@@ -9,7 +9,7 @@
         "role": "consul-client-webclient",
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
+        "proj_suffix_tag": "Q3-2019",
         "type": "{{ env `NODE_TYPE` }}"
     },
     "builders": [{
@@ -47,7 +47,8 @@
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [{

--- a/packer/client_webclient.json
+++ b/packer/client_webclient.json
@@ -10,7 +10,8 @@
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
         "proj_suffix_tag": "Q3-2019",
-        "type": "{{ env `NODE_TYPE` }}"
+        "type": "{{ env `NODE_TYPE` }}",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-{{ user `type` }}-webclient",
@@ -46,6 +47,7 @@
                 "project": "CC Demo {{ user `proj_suffix_tag` }}",
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
+                "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
             },
             "ami_groups": ["all"]

--- a/packer/consul_base.json
+++ b/packer/consul_base.json
@@ -9,8 +9,8 @@
         "role": "consul-base",
         "type": "{{ env `NODE_TYPE` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
-        "consul_version": "1.5.1"
+        "proj_suffix_tag": "Q3-2019",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-base",
@@ -48,7 +48,8 @@
                 "Base_AMI": "{{ .SourceAMI }}",
                 "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [{

--- a/packer/consul_client.json
+++ b/packer/consul_client.json
@@ -9,8 +9,9 @@
         "role": "consul-client",
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
-        "type": "{{ env `NODE_TYPE` }}"
+        "proj_suffix_tag": "Q3-2019",
+        "type": "{{ env `NODE_TYPE` }}",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-client",
@@ -46,8 +47,10 @@
                 "project": "CC Demo {{ user `proj_suffix_tag` }}",
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
+                "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [{

--- a/packer/consul_server.json
+++ b/packer/consul_server.json
@@ -9,8 +9,9 @@
         "role": "consul-server",
         "ami_owner": "{{ env `AMI_OWNER` }}",
         "owner_tag": "thomas@hashicorp.com",
-        "proj_suffix_tag": "FY20Q2",
-        "type": "server"
+        "proj_suffix_tag": "Q3-2019",
+        "type": "server",
+        "consul_version": "{{ env `CONSUL_VER` }}"
     },
     "builders": [{
             "image_name": "cc-demo-consul-{{ user `type` }}",
@@ -46,8 +47,10 @@
                 "project": "CC Demo {{ user `proj_suffix_tag` }}",
                 "Base_AMI_Name": "{{ .SourceAMIName }}",
                 "Base_AMI": "{{ .SourceAMI }}",
+                "consul_version": "{{ user `consul_version` }}",
                 "role": "{{ user `role` }}"
-            }
+            },
+            "ami_groups": ["all"]
         }
     ],
     "provisioners": [{

--- a/packer/files/install_base.sh
+++ b/packer/files/install_base.sh
@@ -1,11 +1,17 @@
 #! /bin/bash
 
-echo "Updating and installing required software..."
-sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq > /dev/null
-sudo DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade > /dev/null
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq unzip wget jq python3-pip > /dev/null
+set -e
 
-sleep 15
+# Wait for cloud-init to finish
+while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
+  echo 'Waiting for cloud-init to finish...'
+  sleep 1
+done
+
+echo "Updating and installing required software..."
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq -y > /dev/null
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade -y > /dev/null
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -qq unzip wget jq python3-pip > /dev/null
 
 # echo "Adding reinvent user"
 # sudo adduser --disabled-password --gecos "reInvent User" reinvent
@@ -14,5 +20,5 @@ sleep 15
 # sudo chown reinvent:reinvent /home/reinvent/.ssh/authorized_keys
 # sudo chmod 600 /home/reinvent/.ssh/authorized_keys
 
-echo "Finished!"
+echo "Package update & install finished!"
 

--- a/packer/files/install_mongodb.sh
+++ b/packer/files/install_mongodb.sh
@@ -1,15 +1,22 @@
 #! /bin/bash
 
+# Wait for cloud-init to finish
+while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
+  echo 'Waiting for cloud-init to finish...'
+  sleep 1
+done
+
 # install mongodb
 echo "### apt-key adv"
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
 sleep 5
 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
 sleep 5
+
 echo "### apt-get update"
-sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq -y > /dev/null
 sleep 5
-sudo apt-get install -y -qq mongodb-org 
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq mongodb-org > /dev/null
 sleep 5
 
 sudo systemctl enable mongod

--- a/packer/files/install_node.sh
+++ b/packer/files/install_node.sh
@@ -1,9 +1,15 @@
 #! /bin/bash
 
+# Wait for cloud-init to finish
+while [ ! -f /var/lib/cloud/instance/boot-finished ]; do
+  echo 'Waiting for cloud-init to finish...'
+  sleep 1
+done
+
 # install Node
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sleep 15
-sudo apt-get install -y nodejs
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nodejs > /dev/null
 sleep 15
 
 # install the listing service app


### PR DESCRIPTION
Changes:
- upgrade Consul to `1.5.2`
- change images **public** so external users can use the demo
- change project-tag suffix to `Q3-2019` (was `FY20Q2`)

Enhancements:
- define `CONSUL_VER` in Makefile and pass value to packer build commands
  - packer reads as environment var
- apply `consul_version` tag to all AMIs (was only on base image)
- fix possible crash during package update step in `install_base.sh`
  - pause execution until cloud-init has finished before `apt-get` commands
- remove error messages during `mongodb` and `listing` builds
  - add `DEBIAN_FRONTEND=noninteractive` before `apt-get` statements