### PR TITLE
Update to support Consul 1.6.0

### DIFF
--- a/packer/Makefile
+++ b/packer/Makefile
@@ -1,7 +1,7 @@
 ENCRYPT_CONFIG := files/encrypt.hcl
 
 AMI_OWNER=753646501470
-CONSUL_VER="1.5.2"
+CONSUL_VER="1.6.0"
 
 DEFAULT:
 	@echo Run 'make aws' to build appropriate images

--- a/packer/client_listing.json
+++ b/packer/client_listing.json
@@ -69,6 +69,11 @@
         },
         {
             "type": "file",
+            "source": "files/listing_proxy.service",
+            "destination": "/tmp/listing_proxy.service"
+        },
+        {
+            "type": "file",
             "source": "demoscripts/listing/",
             "destination": "/home/ubuntu"
         },
@@ -80,10 +85,12 @@
                 "sudo rm -f /tmp/install_node.sh",
                 "sudo mv /tmp/listing.hcl /etc/consul/listing.hcl",
                 "sudo mv /tmp/listing.service /lib/systemd/system/listing.service",
+                "sudo mv /tmp/listing_proxy.service /lib/systemd/system/listing_proxy.service",
                 "sudo chown -R consul:consul /etc/consul",
                 "sudo systemctl daemon-reload",
                 "sudo systemctl enable consul",
                 "sudo systemctl enable listing.service",
+                "sudo systemctl enable listing_proxy.service",
                 "sudo rm -rf /opt/consul/*"
             ]
         }

--- a/packer/client_product.json
+++ b/packer/client_product.json
@@ -68,6 +68,11 @@
             "destination": "/tmp/product.service"
         },
         {
+            "type": "file",
+            "source": "files/product_proxy.service",
+            "destination": "/tmp/product_proxy.service"
+        },
+        {
             "type": "shell",
             "inline": [
                 "sudo chmod a+x /tmp/install_products.sh",
@@ -75,9 +80,11 @@
                 "sudo rm -f /tmp/install_products.sh",
                 "sudo mv /tmp/product.hcl /etc/consul/product.hcl",
                 "sudo mv /tmp/product.service /lib/systemd/system/product.service",
+                "sudo mv /tmp/product_proxy.service /lib/systemd/system/product_proxy.service",
                 "sudo chown -R consul:consul /etc/consul",
                 "sudo systemctl daemon-reload",
                 "sudo systemctl enable product.service",
+                "sudo systemctl enable product_proxy.service",
                 "sudo systemctl enable consul",
                 "sudo rm -rf /opt/consul/*"
             ]

--- a/packer/files/listing_proxy.service
+++ b/packer/files/listing_proxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Listing Consul Connect Proxies
+After=network.target
+StartLimitInterval=0
+
+[Service]
+Type=simple
+User=ubuntu
+ExecStart=/usr/local/bin/consul connect proxy -sidecar-for listing
+Restart=always
+RestartDelay=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packer/files/product_proxy.service
+++ b/packer/files/product_proxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Product Consul Connect Proxies
+After=network.target
+StartLimitInterval=0
+
+[Service]
+Type=simple
+User=ubuntu
+ExecStart=/usr/local/bin/consul connect proxy -sidecar-for product
+Restart=always
+RestartDelay=5
+
+[Install]
+WantedBy=multi-user.target

--- a/packer/services/listing.hcl
+++ b/packer/services/listing.hcl
@@ -6,7 +6,7 @@ service {
   tags                = ["prod"]
 
   connect = {
-    proxy = {}
+    sidecar_service = {}
   }
 
   checks = [

--- a/packer/services/product.hcl
+++ b/packer/services/product.hcl
@@ -5,36 +5,27 @@ service {
   port                = 5000
   tags                = ["prod"]
 
+  checks = [
+    {
+      id         = "product-tcp"
+      interval   = "10s"
+      name       = "product server on 8000"
+      tcp        = "localhost:5000"
+      timeout    = "1s"
+      service_id = "product"
+    },
+    {
+      id              = "product-health"
+      interval        = "10s"
+      timeout         = "1s"
+      name            = "product server /healthz"
+      http            = "http://localhost:5000/product/healthz"
+      tls_skip_verify = true
+      service_id      = "product"
+    },
+  ]
+
   connect = {
-    proxy = {}
+    sidecar_service = {}
   }
 }
-
-checks = [
-  {
-    id         = "product-tcp"
-    interval   = "10s"
-    name       = "product server on 8000"
-    tcp        = "localhost:5000"
-    timeout    = "1s"
-    service_id = "product"
-  },
-  {
-    id              = "product-health"
-    interval        = "10s"
-    timeout         = "1s"
-    name            = "product server /healthz"
-    http            = "http://localhost:5000/product/healthz"
-    tls_skip_verify = true
-    service_id      = "product"
-  },
-  {
-    id              = "product-proxy-health"
-    interval        = "10s"
-    timeout         = "1s"
-    name            = "product server /healthz"
-    http            = "http://localhost:5000/product/healthz"
-    tls_skip_verify = true
-    service_id      = "product-proxy"
-  },
-]

--- a/terraform/aws/multi-region-demo/main.tf
+++ b/terraform/aws/multi-region-demo/main.tf
@@ -112,12 +112,6 @@ resource "consul_keys" "server_ips_main" {
   }
 
   key {
-    path   = "product/enable_hyper_speed"
-    value  = "true"
-    delete = true
-  }
-
-  key {
     path   = "product/run"
     value  = "true"
     delete = true
@@ -131,12 +125,6 @@ resource "consul_keys" "server_ips_alt" {
   key {
     path  = "server_ips"
     value = "${join(" ", concat(module.cluster_main.consul_servers_private_ip, module.cluster_alt.consul_servers_private_ip))}"
-  }
-
-  key {
-    path   = "product/enable_hyper_speed"
-    value  = "true"
-    delete = true
   }
 
   key {

--- a/terraform/aws/multi-region-demo/outputs.tf
+++ b/terraform/aws/multi-region-demo/outputs.tf
@@ -34,34 +34,50 @@ output "main_product_api_servers" {
 }
 
 # Alternate Cluster Outputs
-output "alt_region" {
+output "secondary_region" {
   value = "${module.cluster_alt.aws_region}"
 }
 
-output "alt_consul_lb" {
+output "secondary_consul_lb" {
   value = "${module.cluster_alt.consul_lb}"
 }
 
-output "alt_consul_servers" {
+output "secondary_consul_servers" {
   value = ["${module.cluster_alt.consul_servers}"]
 }
 
-output "alt_webclient_lb" {
+output "secondary_webclient_lb" {
   value = "${module.cluster_alt.webclient_lb}"
 }
 
-output "alt_webclient_servers" {
+output "secondary_webclient_servers" {
   value = ["${module.cluster_alt.webclient_servers}"]
 }
 
-output "alt_listing_api_servers" {
+output "secondary_listing_api_servers" {
   value = ["${module.cluster_alt.listing_api_servers}"]
 }
 
-output "alt_mongo_servers" {
+output "secondary_mongo_servers" {
   value = ["${module.cluster_alt.mongo_servers}"]
 }
 
-output "alt_product_api_servers" {
+output "secondary_product_api_servers" {
   value = ["${module.cluster_alt.product_api_servers}"]
+}
+
+# Display Demo Connection Information at end
+output "working_connections" {
+  value = <<EOF
+
+
+  OPEN IN BROWSER TABS
+    Webclient   http://${module.cluster_main.webclient_lb}
+    Consul GUI  http://${module.cluster_main.consul_lb}
+
+  CONNECT IN TERMINAL TABS:
+    ssh ubuntu@${element(module.cluster_main.listing_api_servers, 0)}
+    ssh ubuntu@${element(module.cluster_main.webclient_servers, 0)}
+
+EOF
 }

--- a/terraform/aws/multi-region-demo/variables.tf
+++ b/terraform/aws/multi-region-demo/variables.tf
@@ -41,11 +41,6 @@ variable "ssh_pri_key_file" {
   default     = ""
 }
 
-# Do we need this in multi-region TF file?  Isnt it always the DC of main?
-# variable "consul_acl_dc" {
-#   description = "Consul ACL cluster name"
-# }
-
 variable "route53_zone_id" {
   description = "Route 53 zone into which to place hostnames"
 }

--- a/terraform/aws/single-region-demo/main.tf
+++ b/terraform/aws/single-region-demo/main.tf
@@ -43,10 +43,4 @@ resource "consul_keys" "keys" {
     value  = "true"
     delete = true
   }
-
-  key {
-    path   = "product/enable_hyper_speed"
-    value  = "true"
-    delete = true
-  }
 }

--- a/terraform/aws/single-region-demo/outputs.tf
+++ b/terraform/aws/single-region-demo/outputs.tf
@@ -1,33 +1,49 @@
 # Outputs
 
-output "cluster_region" {
+output "main_cluster_region" {
   value = "${module.cluster_main.aws_region}"
 }
 
-output "consul_lb" {
+output "main_consul_lb" {
   value = "${module.cluster_main.consul_lb}"
 }
 
-output "consul_servers" {
+output "main_consul_servers" {
   value = ["${module.cluster_main.consul_servers}"]
 }
 
-output "webclient_lb" {
+output "main_webclient_lb" {
   value = "${module.cluster_main.webclient_lb}"
 }
 
-output "webclient_servers" {
+output "main_webclient_servers" {
   value = ["${module.cluster_main.webclient_servers}"]
 }
 
-output "listing_api_servers" {
+output "main_listing_api_servers" {
   value = ["${module.cluster_main.listing_api_servers}"]
 }
 
-output "mongo_servers" {
+output "main_mongo_servers" {
   value = ["${module.cluster_main.mongo_servers}"]
 }
 
-output "product_api_servers" {
+output "main_product_api_servers" {
   value = ["${module.cluster_main.product_api_servers}"]
+}
+
+# Display Demo Connection Information at end
+output "working_connections" {
+  value = <<EOF
+
+
+  OPEN IN BROWSER TABS
+    Webclient   http://${module.cluster_main.webclient_lb}
+    Consul GUI  http://${module.cluster_main.consul_lb}
+
+  CONNECT IN TERMINAL TABS:
+    ssh ubuntu@${element(module.cluster_main.listing_api_servers, 0)}
+    ssh ubuntu@${element(module.cluster_main.webclient_servers, 0)}
+
+EOF
 }

--- a/terraform/aws/single-region-demo/variables.tf
+++ b/terraform/aws/single-region-demo/variables.tf
@@ -22,10 +22,6 @@ variable "consul_dc" {
   description = "Consul cluster DC name"
 }
 
-# variable "consul_acl_dc" {
-#   description = "Consul ACL cluster name"
-# }
-
 variable "route53_zone_id" {
   description = "Route 53 zone into which to place hostnames"
 }


### PR DESCRIPTION
Fixes and adjustments

- Support Consul 1.6.0
  - adjust packager image builds for `listing` and `product`
    - change service config to use `sidecar_service` instead of the deprecated `proxy`
    - add systemd service that runs a proxy sidecar
- Multi-datacenter deployments synchronize much quicker
  - no longer need to wait 20-25 mins
- New output block (listed at end) that lists web url's and main ssh connections
- Removed unnecessary extra k/v entry from consul
